### PR TITLE
Fix warning from ts-jest about js file

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
     preset: 'ts-jest/presets/js-with-ts',
     roots: ['<rootDir>/src'],
-    transformIgnorePatterns: ['/node_modules/(?!(@guardian)/)'],
+    transformIgnorePatterns: ['/node_modules/'],
 };


### PR DESCRIPTION
Locally and in Team City running `yarn test` emits the following warning:

```
ts-jest[ts-jest-transformer] (WARN) Got a `.js` file to compile while `allowJs` option is not set to `true` (file: /Users/tom_wey/code/image-url-signing-service/node_modules/@guardian/image/dist/image.js). To fix this:
  - if you want TypeScript to process JS files, set `allowJs` to `true` in your TypeScript config (usually tsconfig.json)
  - if you do not want TypeScript to process your `.js` files, in your Jest config change the `transform` key which value is `ts-jest` so that it does not match `.js` files anymore
  - ```

Ignore all of node_modules for now, without the exception for `@guardian` namespaced modules.