### PR TITLE
Rename script from deploy -> riffraff

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -7,4 +7,4 @@ set -e
 yarn install
 yarn test
 yarn build
-yarn deploy
+yarn riffraff

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "prebuild": "rm -rf dist",
     "build": "tsc",
     "postbuild": "./bin/package",
-    "deploy": "node-riffraff-artifact"
+    "riffraff": "node-riffraff-artifact"
   }
 }


### PR DESCRIPTION
I think this name is slightly clearer, since it doesn't actually deploy anything.