### PR TITLE
Small tweaks to build process

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -6,5 +6,5 @@ set -e
 
 yarn install
 yarn test
-yarn compile
+yarn build
 yarn deploy

--- a/bin/package
+++ b/bin/package
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+cp package.json dist/
+cp yarn.lock dist/
+cd dist
+yarn install --production
+cd ..

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "test": "jest",
-    "compile": "tsc && cp package.json dist/package.json && npm install --prefix dist --production",
+    "prebuild": "rm -rf dist",
+    "build": "tsc",
+    "postbuild": "./bin/package",
     "deploy": "node-riffraff-artifact"
   }
 }


### PR DESCRIPTION
* Remove the `dist` directory before building to ensure a clean slate each time.
* Split out the separate steps of building (i.e. prebuild, build, postbuild)
* I noticed that we were using `npm` to install deps so switch to yarn (and cp the lockfile across for consistent deps). `yarn` doesn't seem to support a --prefix like `npm` so I switched to using a script where I can cd into/out of the `dist` dir.