### PR TITLE
Refactor `signed-image-url` handlers

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -88,6 +88,9 @@ function withPandaAuth(
 				error: 'Pan domain auth error',
 				ex: ex,
 			});
+		})
+		.finally(() => {
+			panda.stop();
 		});
 }
 


### PR DESCRIPTION
## What does this change?

Separates out the `GET`/`POST` `signed-image-url` handlers, instead of using `all` which responds to all HTTP verbs. Also start separating out the auth concerns from the image signing business logic. I’d like to further refactor `handleImageSigning` to have no knowledge of the request and response objects but will do that separately.

Note that there’s a functional change here where the auth runs before any of the business logic (e.g. payload validation) which I think is what we want.

## How to test

`yarn test`