### PR TITLE
Force local when running `yarn dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript": "^4.3.4"
   },
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "dev": "LOCAL=true ts-node-dev --respawn --transpile-only src/index.ts",
     "test": "jest",
     "prebuild": "rm -rf dist",
     "build": "tsc",


### PR DESCRIPTION
## What does this change?

Running `yarn dev` sets the `LOCAL` environment variable to true for the process. I think we always want to spin up a local server when running `yarn dev`.

## How to test

Run `yarn dev` locally (without setting `LOCAL`!)