### PR TITLE
Add UI to root endpoint

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -17,5 +17,16 @@ function getSettingsFile(stage: string | undefined) {
 	}
 }
 
+export function getLoginUrl(stage: string | undefined) {
+	switch (stage) {
+		case 'CODE':
+			return 'https://login.code.dev-gutools.co.uk';
+		case 'PROD':
+			return 'https://login.gutools.co.uk';
+		default:
+			return 'https://login.local.dev-gutools.co.uk';
+	}
+}
+
 export const SETTINGS_FILE = getSettingsFile(getStage());
 export const REGION = process.env.AWS_REGION || 'eu-west-1';


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Adds a simple form UI to the root / GET endpoint so that going to:
- https://image-url-signing-service.local.dev-gutools.co.uk/
- https://image-url-signing-service.code.dev-gutools.co.uk/
- https://image-url-signing-service.gutools.co.uk/

Will display a UI for submitting a GET request to the signed-image-url endpoint.

This is to replace and ultimately deprecate https://github.com/guardian/image-url-signer-lambda

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
It does everything the UI in https://github.com/guardian/image-url-signer-lambda does.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
This is a really simple way of getting a UI setup, if any more features are needed in future it might become clunky to maintain.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
