### PR TITLE
Update Cloudformation to specify Node 18

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -73,7 +73,7 @@ Resources:
       MemorySize: 128
       Role:
         'Fn::GetAtt': ['ExecutionRole', 'Arn']
-      Runtime: nodejs14.x
+      Runtime: nodejs18.x
       Timeout: 60
 
   ImageSigningLambdaApiPermission:


### PR DESCRIPTION
## What does this change?

In #207 we updated the nvmrc file to specify Node 18, but the actual runtime in AWS is determined by the Cloudformation. This PR updates the Cloudformation to specify Node 18.

The build, which uses the nvmrc file, has already been using Node 18 for a while.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
