### PR TITLE
add pixel tracking img for stage to html template

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -28,5 +28,16 @@ export function getLoginUrl(stage: string | undefined): string {
 	}
 }
 
+export function getUserTelemetryClient(stage: string | undefined): string {
+	switch (stage) {
+		case 'CODE':
+			return 'https://user-telemetry.code.dev-gutools.co.uk';
+		case 'PROD':
+			return 'https://user-telemetry.gutools.co.uk';
+		default:
+			return 'https://user-telemetry.local.dev-gutools.co.uk';
+	}
+}
+
 export const SETTINGS_FILE = getSettingsFile(getStage());
 export const REGION = process.env.AWS_REGION || 'eu-west-1';

--- a/src/uiHtml.ts
+++ b/src/uiHtml.ts
@@ -1,6 +1,6 @@
 import type { AuthenticationResult } from '@guardian/pan-domain-node';
 import type express from 'express';
-import { getLoginUrl, getStage } from './environment';
+import { getLoginUrl, getStage, getUserTelemetryClient } from './environment';
 
 export function getUI(authResult?: AuthenticationResult): string {
 	let userNameString = '';
@@ -12,6 +12,7 @@ export function getUI(authResult?: AuthenticationResult): string {
 	if (authResult?.user?.avatarUrl) {
 		avatarHtml = `<img id="avatar-img" style="width: 32px; height: 32px; border-radius: 32px;" src="${authResult.user.avatarUrl}">`;
 	}
+	const pixelTrackingUrl = `${getUserTelemetryClient(getStage())}/guardian-tool-accessed?app=image-url-signing-service&path=/`
 
 	const stage = getStage() ?? 'PROD';
 	const lambdaName = `image-url-signing-service-${stage}`;
@@ -128,6 +129,7 @@ export function getUI(authResult?: AuthenticationResult): string {
 
 				  }
 			  </script>
+			  <img style="display:none;" src="${pixelTrackingUrl}">
 		</body>
 	</html>
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds the [Tools Audit tracking pixel](https://github.com/guardian/editorial-tools-user-telemetry-service?tab=readme-ov-file#tracking-pixel) to allow us to see how frequently this application is being used by different users. The results will be visible here: https://metrics.gutools.co.uk/d/aegzv59r9eghsd/tool-audit?orgId=1&var-domain=image-url-signing-service.gutools.co.uk&var-path=All&var-interval=1d&var-chosen_apps=All

## How to test

Deploy to code. Open and refresh a few times.
the traffic should be visible on the dashboard for CODE:
https://metrics.gutools.co.uk/d/aegzv59r9eghsd/tool-audit?orgId=1&var-domain=code.image-url-signing-service.dev-gutools.co.uk&var-path=All&var-interval=1d&var-chosen_apps=All

## How can we measure success?

We gather telemetry on the usage of this tool.

## Have we considered potential risks?

Should be safe - worse case, the tracking does not work and the pixel fails to load.
