### PR TITLE
add dependency needed to allow deployment

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -172,3 +172,5 @@ Resources:
       RestApiId: !Ref ImageSigningApi
       DomainName: !FindInMap ['DomainNames', !Ref Stage, 'Name']
       Stage: !Ref Stage
+    DependsOn:
+      - ImageSigningApiCustomDomain


### PR DESCRIPTION
I had to drop and recreate the stack due to the deployment referenced in the stack being a broken one, and it kept reverting back on every deploy.
I couldn't work out how to fix the broken deployment without dropping and recreating the stack.
When trying to recreate it, it failed due to the mapping being created before the domain.

This PR adds a dependency to make sure they're created in the right order.
https://stackoverflow.com/a/51307661/2076522

