### PR TITLE
Adopt the DNS record into the cloudformation stack

### DIFF
--- a/cfn.yaml
+++ b/cfn.yaml
@@ -174,3 +174,18 @@ Resources:
       Stage: !Ref Stage
     DependsOn:
       - ImageSigningApiCustomDomain
+
+  ImageSigningApiDNSRecord:
+    Type: Guardian::DNS::RecordSet
+    Properties:
+      Name: !FindInMap ['DomainNames', !Ref Stage, 'Name']
+      RecordType: CNAME
+      ResourceRecords:
+        - Fn::Join:
+          - "."
+          - - !Ref ImageSigningApi
+            - execute-api
+            - !Ref AWS::Region
+            - !Ref AWS::URLSuffix
+      Stage: !Ref Stage
+      TTL: 3600


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We discovered that the DNS record had not been yet incorporated into the cloudformation after [dropping and recreating the stack which broke the link](https://mail.google.com/chat/u/0/#chat/space/AAAAag0I08g/TYC4QbVh9jw/TYC4QbVh9jw). 

DevX developed a custom resource to [manage DNS](https://groups.google.com/a/guardian.co.uk/g/engineering/c/Y6As7_7ovl8/m/jscQnVPZAwAJ) through CloudFormation ([example](https://github.com/guardian/janus/pull/3449/files)).

This pull request uses the custom resource to[adopts the DNS record of the domain ](https://github.com/guardian/cfn-private-resource-types/blob/main/dns/guardian-dns-record-set-type/README.md)for image URL signing service into its cloudformation stack.

It allows updating the CNAME record of the domain name automatically when there are any changes to the API gateway endpoint.

It also makes it easier to manage the DNS record such as changing the TTL.

The DNS record in the cloudformation must exactly match with the record on NS1 when we adopt it into the cloudformation for the first time.

## Validation

After deployment, we should check if the record has been adopted correctly via the [service catalogue](https://metrics.gutools.co.uk/goto/x8dkmGwNR?orgId=1). 

## Remark

Once the DNS record has been adopted, it is fully managed by the cloudformation stack.  So if the stack is rolled back and the DNS record resource is removed, the NS1 record is deleted as well. 